### PR TITLE
v0.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ dist/
 docs/docker/
 docs/jsdoc/
 docs/jsdoc-conf.json
+test/specs/coverage/
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -61,7 +61,14 @@
     "extends": "./src/babel-config.js"
   },
   "eslintConfig": {
-    "extends": "./src/eslint-config.js"
+    "extends": "./src/eslint-config.js",
+    "rules": {
+      "no-await-in-loop": 0,
+      "no-console": 0,
+      "import/no-dynamic-require": 0,
+      "no-restricted-syntax": 0, 
+      "no-unused-vars": 0
+    }
   },
   "eslintIgnore": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creatartis/creatartis-build",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Build setup for Creatartis' projects",
   "main": "dist/creatartis-build.js",
   "bin": {

--- a/src/babel-config.js
+++ b/src/babel-config.js
@@ -31,5 +31,5 @@ module.exports = {
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-syntax-import-meta',
   ],
-  sourceMaps: 'inline',
+  sourceMaps: true,
 };

--- a/src/creatartis-build.js
+++ b/src/creatartis-build.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable no-console */
-/* eslint-disable no-await-in-loop, no-restricted-syntax, no-unused-vars */
 const { spawn } = require('child_process');
 const { promises: fs } = require('fs');
 const path = require('path');
@@ -29,10 +27,9 @@ function taskPwd() {
 
 async function taskLint() {
   const ignored = ['/dist', '/node_modules', '/docs']
-    .map((pattern) => `--ignore-pattern ${pattern}`).join(' ');
-  return run(`
-    npx eslint . --ext js,jsx --quiet ${ignored}
-  `);
+    .map((pattern) => `--ignore-pattern ${pattern}`)
+    .join(' ');
+  return run(`npx eslint . --ext js,jsx --quiet ${ignored}`);
 }
 
 async function taskTest() {
@@ -49,9 +46,7 @@ async function taskBuild(type) {
     `);
   }
   if (!type || type === 'esm') {
-    await run(`
-      npx babel src/ --out-dir dist/
-    `);
+    await run('npx babel src/ --out-dir dist/');
   }
 }
 
@@ -62,12 +57,24 @@ async function taskDoc() {
   `);
 }
 
-async function taskPublish(registry) {
-  if (registry === 'verdaccio') {
-    await run(`
-      npm publish --registry http://localhost:4873
-    `);
-  }
+function getNPMRegistry(id) {
+  if (!id) return null;
+  if (/^(verdaccio|local)$/.test(id)) return 'http://localhost:4873';
+  if (/^(npm)$/.test(id)) return 'https://registry.npmjs.org/';
+  if (/^\d+/.test(id)) return `http://localhost:${id}`;
+  throw new Error(`Unrecognized NPM registry ${id}!`);
+}
+
+async function taskPublish(id) {
+  const registryURL = getNPMRegistry(id);
+  const registry = registryURL ? `--registry ${registryURL}` : '';
+  await run(`npm publish ${registry}`);
+}
+
+async function taskUnpublish(id) {
+  const registryURL = getNPMRegistry(id);
+  const registry = registryURL ? `--registry ${registryURL}` : '';
+  await run(`npm unpublish ${registry} --force`);
 }
 
 const TASKS = [
@@ -79,6 +86,8 @@ const TASKS = [
   [/doc/, taskDoc],
   [/default/, taskLint, taskBuild, taskTest, taskDoc],
   [/publish(?::(\w+))/, taskPublish],
+  [/unpublish(?::(\w+))/, taskUnpublish],
+  [/republish(?::(\w+))/, taskUnpublish, taskPublish],
 ];
 
 async function execTask(id) {

--- a/src/creatartis-build.js
+++ b/src/creatartis-build.js
@@ -2,7 +2,7 @@
 const { spawn } = require('child_process');
 const { promises: fs } = require('fs');
 const path = require('path');
-// eslint-disable-next-line import/no-dynamic-require
+
 const packageJSON = require(`${process.cwd()}/package.json`);
 
 // Utilities ///////////////////////////////////////////////////////////////////

--- a/src/creatartis-build.js
+++ b/src/creatartis-build.js
@@ -46,7 +46,7 @@ async function taskBuild(type) {
     `);
   }
   if (!type || type === 'esm') {
-    await run('npx babel src/ --out-dir dist/');
+    await run('npx babel src/ --out-dir dist/ --source-maps=true');
   }
 }
 

--- a/src/jest-config.js
+++ b/src/jest-config.js
@@ -4,8 +4,8 @@ const { jest } = require(`${process.cwd()}/package.json`);
 
 module.exports = {
   collectCoverage: true,
-  collectCoverageFrom: ['src/'],
-  coverageDirectory: 'test/specs/coverage',
+  collectCoverageFrom: ['src/**/*.{js,jsx}', 'test/**/*.test.{js,jsx}'],
+  coverageDirectory: 'test/specs/coverage/',
   coverageReporters: ['json', 'text-summary'],
   rootDir: process.cwd(),
   setupFilesAfterEnv: [

--- a/src/jest-config.js
+++ b/src/jest-config.js
@@ -3,6 +3,10 @@ const path = require('path');
 const { jest } = require(`${process.cwd()}/package.json`);
 
 module.exports = {
+  collectCoverage: true,
+  collectCoverageFrom: ['src/'],
+  coverageDirectory: 'test/specs/coverage',
+  coverageReporters: ['json', 'text-summary'],
   rootDir: process.cwd(),
   setupFilesAfterEnv: [
     path.join(__dirname, 'jest-setup.js'),

--- a/src/jest-config.js
+++ b/src/jest-config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-// eslint-disable-next-line import/no-dynamic-require
+
 const { jest } = require(`${process.cwd()}/package.json`);
 
 module.exports = {

--- a/src/jest-setup.js
+++ b/src/jest-setup.js
@@ -1,4 +1,3 @@
-/* eslint-disable valid-typeof */
 global.expect.extend({
   /** Tests the type of the received value. If `type` is a string the `typeof`
    * operator is used. Else it is assumed `type` is a function, and the
@@ -6,6 +5,7 @@ global.expect.extend({
   */
   toBeOfType(received, type) {
     const pass = typeof type === 'string'
+      // eslint-disable-next-line valid-typeof
       ? (typeof received === type)
       : (received instanceof type);
     if (pass) {

--- a/src/jsdoc-config.js
+++ b/src/jsdoc-config.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-dynamic-require
 const { jsdoc } = require(`${process.cwd()}/package.json`);
 
 module.exports = {

--- a/src/webpack-config.js
+++ b/src/webpack-config.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-dynamic-require
 const packageJSON = require(`${process.cwd()}/package.json`);
 
 const parsePackageName = (name) => {


### PR DESCRIPTION
+ Add tasks `publish:npm`, `unpublish:verdaccio`, `republish:verdaccio`.
+ Add coverage metrics with Jest.
+ Put sourcemaps in separate files instead of inline. 